### PR TITLE
Avoid sending too many events

### DIFF
--- a/killer shuffle - F2 on.ahk
+++ b/killer shuffle - F2 on.ahk
@@ -19,8 +19,8 @@ IsWDown := false
         if (!IsEnabled)
             break
 
-        holdKey("w", 50, &IsWDown)
-        holdKey("s", 50, &IsSDown)
+        holdKey("w", 100, &IsWDown)
+        holdKey("s", 100, &IsSDown)
     }
 }
 


### PR DESCRIPTION
Multiple users reported they got warnings/errors for macros sending too many events. This doubles the stroke length and halves the number of events.